### PR TITLE
chore(build): add typescript declaration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,8 @@
         "sirv-cli": "^2.0.2",
         "svelte": "^3.46.2",
         "svelte-markdown": "^0.2.3",
-        "svelte-preprocess": "^4.10.2"
+        "svelte-preprocess": "^4.10.2",
+        "typescript": "^4.9.5"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -5538,6 +5539,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/ua-parser-js": {
       "version": "1.0.33",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.33.tgz",
@@ -9722,6 +9736,12 @@
         "for-each": "^0.3.3",
         "is-typed-array": "^1.1.9"
       }
+    },
+    "typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true
     },
     "ua-parser-js": {
       "version": "1.0.33",

--- a/package.json
+++ b/package.json
@@ -3,10 +3,12 @@
   "version": "0.0.11",
   "description": "A component for scroll-based (or other externally controlled) playback.",
   "main": "dist/scrolly-video.js",
+  "types": "dist/ScrollyVideo.d.ts",
   "scripts": {
     "dev": "DOCS_SITE=true rollup -c -w",
     "build": "rimraf dist && rollup -c",
     "build-docs": "rimraf build && DOCS_SITE=true rollup -c",
+    "postbuild": "tsc",
     "start": "sirv build",
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "eslint .",
@@ -58,6 +60,7 @@
     "sirv-cli": "^2.0.2",
     "svelte": "^3.46.2",
     "svelte-markdown": "^0.2.3",
-    "svelte-preprocess": "^4.10.2"
+    "svelte-preprocess": "^4.10.2",
+    "typescript": "^4.9.5"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "allowJs": true,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "outDir": "dist"
+  },
+}


### PR DESCRIPTION
Add a post-build step to emit TS declaration file based on the JS source

A typescript rewrite would be better, but as you said that you weren't used to typescript, i think this approach works the best

**Related:** #30