### PR TITLE
Destroy 'scroll' event listener

### DIFF
--- a/src/ScrollyVideo.js
+++ b/src/ScrollyVideo.js
@@ -129,7 +129,7 @@ class ScrollyVideo {
     // Add our event listeners for handling changes to the window or scroll
     if (this.trackScroll) {
       // eslint-disable-next-line no-undef
-      window.addEventListener('scroll', () => this.updateScrollPercentage());
+      window.addEventListener('scroll', this.updateScrollPercentage);
 
       // Set the initial scroll percentage
       this.video.addEventListener(
@@ -370,6 +370,8 @@ class ScrollyVideo {
    * Call to destroy this ScrollyVideo object
    */
   destroy() {
+    if (this.debug) console.info('Destroying ScrollyVideo');
+
     // eslint-disable-next-line no-undef
     if (this.trackScroll) window.removeEventListener('scroll', this.updateScrollPercentage);
 

--- a/src/ScrollyVideo.jsx
+++ b/src/ScrollyVideo.jsx
@@ -6,8 +6,8 @@ function ScrollyVideoComponent(props) {
   // variable to hold the DOM element
   const containerElement = useRef(null);
 
-  // variable to hold the scrollyVideo object
-  const [scrollyVideo, setScrollyVideo] = useState(null);
+  // ref to hold the scrollyVideo object
+  const scrollyVideoRef = useRef(null);
 
   // Store the props so we know when things change
   const [lastPropsString, setLastPropsString] = useState('');
@@ -19,22 +19,22 @@ function ScrollyVideoComponent(props) {
 
       if (JSON.stringify(restProps) !== lastPropsString) {
         // if scrollyvideo already exists and any parameter is updated, destroy and recreate.
-        if (scrollyVideo && scrollyVideo.destroy) scrollyVideo.destroy();
-        setScrollyVideo(new ScrollyVideo({ scrollyVideoContainer: containerElement.current, ...props }));
+        if (scrollyVideoRef.current && scrollyVideoRef.current.destroy) scrollyVideoRef.current.destroy();
+        scrollyVideoRef.current = new ScrollyVideo({ scrollyVideoContainer: containerElement.current, ...props });
 
         // Save the new props
         setLastPropsString(JSON.stringify(restProps));
       }
 
       // If we need to update the target time percent
-      if (scrollyVideo && typeof videoPercentage === 'number' && videoPercentage >= 0 && videoPercentage <= 1) {
-        scrollyVideo.setTargetTimePercent(videoPercentage);
+      if (scrollyVideoRef.current && typeof videoPercentage === 'number' && videoPercentage >= 0 && videoPercentage <= 1) {
+        scrollyVideoRef.current.setTargetTimePercent(videoPercentage);
       }
     }
 
     // Cleanup the component on unmount
     return () => {
-      if (scrollyVideo && scrollyVideo.destroy) scrollyVideo.destroy();
+      if (scrollyVideoRef.current && scrollyVideoRef.current.destroy) scrollyVideoRef.current.destroy();
     }
   }, [containerElement, props]);
 


### PR DESCRIPTION
## Description
In debug mode, I noticed that the 'scroll' event listener was still firing, despite the ScrollyVideo component being removed. 

![Event Listener Not Destroyed](https://user-images.githubusercontent.com/110618659/222280724-f6e6ba4e-10a7-434b-9f2a-1f688dc7f246.png)

After some investigation, I found that this was because 
1. the `scrollyVideo.destroy()` method was never reached in the React component.
1. the anonymous function wrapping `this.updateScrollPercentage` in the `addEventListener` prevented `removeEventListener` from destroying it.


### React Component
 `(scrollyVideo && scrollyVideo.destroy)` always evaluated false and the `scrollyVideo.destroy()` method couldn't be reached. `setScrollyVideo` is called inside the `useEffect` hook, and it may not be set when the cleanup function is called.

```jsx
const containerElement = useRef(null);
const [scrollyVideo, setScrollyVideo] = useState(null);

useEffect(() => {

  setScrollyVideo(new ScrollyVideo())

  return () => {
    if (scrollyVideo && scrollyVideo.destroy) scrollyVideo.destroy();
  }
}, [containerElement, props]);
```

I fixed this by using `useRef` instead of `useState` to hold the `new ScrollyVideo`.

```jsx
const containerElement = useRef(null);
const scrollyVideoRef = useRef(null);

useEffect(() => {

  scrollyVideoRef.current = new ScrollyVideo()

  return () => {
    if (scrollyVideoRef.current && scrollyVideoRef.current.destroy) {
      scrollyVideo.destroy();
  }
}, [containerElement, props]);
```

### Event Listener

Once `destroy()` could be called, I noticed the event listener was still not being destroyed. After further investigation, I found the anonymous function wrapping `this.updateScrollPercentage()` prevented the `removeEventListener` from finding it.

```js
window.addEventListener('scroll', () => this.updateScrollPercentage());
window.removeEventListener('scroll', this.updateScrollPercentage);
```

was changed to

```js
window.addEventListener('scroll', this.updateScrollPercentage;
window.removeEventListener('scroll', this.updateScrollPercentage);
```

### Other
These changes were tested in React and Vanilla JS but not Svelte, or Vue (as I don't know anything about them).