### PR TITLE
Feat: align trackScroll with videoPercentage

### DIFF
--- a/src/ScrollyVideo.js
+++ b/src/ScrollyVideo.js
@@ -475,6 +475,11 @@ class ScrollyVideo {
    * @param percentage
    */
   setScrollPercent(percentage) {
+    if (!this.trackScroll) {
+      console.warn('`setScrollPercent` requires enabled `trackScroll`');
+      return;
+    }
+
     const parent = this.container.parentNode;
     const { top, height } = parent.getBoundingClientRect();
 

--- a/src/ScrollyVideo.js
+++ b/src/ScrollyVideo.js
@@ -408,6 +408,20 @@ class ScrollyVideo {
     this.transitionToTargetTime(jump);
   }
 
+  setPercentage(percentage) {
+    const parent = this.container.parentNode;
+    const { top, height } = parent.getBoundingClientRect();
+
+    // eslint-disable-next-line no-undef
+    const startPoint = top + window.pageYOffset;
+    // eslint-disable-next-line no-undef
+    const containerHeightInViewport = height - window.innerHeight;
+    const targetPoint = startPoint + containerHeightInViewport * percentage;
+
+    // eslint-disable-next-line no-undef
+    window.scrollTo({ top: targetPoint });
+  }
+
   /**
    * Call to destroy this ScrollyVideo object
    */

--- a/src/ScrollyVideo.js
+++ b/src/ScrollyVideo.js
@@ -408,7 +408,12 @@ class ScrollyVideo {
     this.transitionToTargetTime(jump);
   }
 
-  setPercentage(percentage) {
+  /**
+   * Simulate trackScroll programmatically (scrolls on page by percentage of video)
+   *
+   * @param percentage
+   */
+  setScrollPercent(percentage) {
     const parent = this.container.parentNode;
     const { top, height } = parent.getBoundingClientRect();
 

--- a/src/ScrollyVideo.jsx
+++ b/src/ScrollyVideo.jsx
@@ -76,9 +76,13 @@ const ScrollyVideoComponent = forwardRef(function ScrollyVideoComponent(
       videoPercentage >= 0 &&
       videoPercentage <= 1
     ) {
-      scrollyVideoRef.current.setTargetTimePercent(videoPercentage);
+      if (trackScroll) {
+        scrollyVideoRef.current.setScrollPercent(videoPercentage)
+      } else {
+        scrollyVideoRef.current.setTargetTimePercent(videoPercentage);
+      }
     }
-  }, [videoPercentage]);
+  }, [videoPercentage, trackScroll]);
 
   // effect for unmount
   useEffect(
@@ -93,8 +97,8 @@ const ScrollyVideoComponent = forwardRef(function ScrollyVideoComponent(
   useImperativeHandle(
     ref,
     () => ({
-      setPercentage: scrollyVideoRef.current
-        ? scrollyVideoRef.current.setPercentage.bind(instance)
+      setScrollPercent: scrollyVideoRef.current
+        ? scrollyVideoRef.current.setScrollPercent.bind(instance)
         : () => {},
     }),
     [instance],

--- a/src/ScrollyVideo.jsx
+++ b/src/ScrollyVideo.jsx
@@ -1,20 +1,31 @@
-import React, { useEffect, useRef } from 'react';
+import React, {
+  forwardRef,
+  useEffect,
+  useState,
+  useRef,
+  useImperativeHandle,
+} from 'react';
 import ScrollyVideo from './ScrollyVideo';
 
-function ScrollyVideoComponent({
-  src,
-  transitionSpeed,
-  frameThreshold,
-  cover,
-  sticky,
-  full,
-  trackScroll,
-  useWebCodecs,
-  videoPercentage,
-  debug,
-}) {
+const ScrollyVideoComponent = forwardRef(function ScrollyVideoComponent(
+  {
+    src,
+    transitionSpeed,
+    frameThreshold,
+    cover,
+    sticky,
+    full,
+    trackScroll,
+    useWebCodecs,
+    videoPercentage,
+    debug,
+  },
+  ref,
+) {
   const containerElement = useRef(null);
   const scrollyVideoRef = useRef(null);
+
+  const [instance, setInstance] = useState(null);
 
   const videoPercentageRef = useRef(videoPercentage);
   videoPercentageRef.current = videoPercentage;
@@ -28,7 +39,7 @@ function ScrollyVideoComponent({
       scrollyVideoRef.current.destroy();
     }
 
-    scrollyVideoRef.current = new ScrollyVideo({
+    const scrollyVideo = new ScrollyVideo({
       scrollyVideoContainer: containerElement.current,
       src,
       transitionSpeed,
@@ -41,6 +52,9 @@ function ScrollyVideoComponent({
       debug,
       videoPercentage: videoPercentageRef.current,
     });
+
+    setInstance(scrollyVideo);
+    scrollyVideoRef.current = scrollyVideo;
   }, [
     src,
     transitionSpeed,
@@ -76,7 +90,17 @@ function ScrollyVideoComponent({
     [],
   );
 
+  useImperativeHandle(
+    ref,
+    () => ({
+      setPercentage: scrollyVideoRef.current
+        ? scrollyVideoRef.current.setPercentage.bind(instance)
+        : () => {},
+    }),
+    [instance],
+  );
+
   return <div ref={containerElement} />;
-}
+});
 
 export default ScrollyVideoComponent;

--- a/src/ScrollyVideo.jsx
+++ b/src/ScrollyVideo.jsx
@@ -24,7 +24,6 @@ const ScrollyVideoComponent = forwardRef(function ScrollyVideoComponent(
 ) {
   const containerElement = useRef(null);
   const scrollyVideoRef = useRef(null);
-
   const [instance, setInstance] = useState(null);
 
   const videoPercentageRef = useRef(videoPercentage);
@@ -107,7 +106,7 @@ const ScrollyVideoComponent = forwardRef(function ScrollyVideoComponent(
     [instance],
   );
 
-  return <div ref={containerElement} />;
+  return <div ref={containerElement} data-scrolly-container />;
 });
 
 export default ScrollyVideoComponent;

--- a/src/ScrollyVideo.svelte
+++ b/src/ScrollyVideo.svelte
@@ -10,7 +10,7 @@
 
   // Store the props so we know when things change
   let lastPropsString = '';
-  
+
   $: {
     if (scrollyVideoContainer) {
       // separate out the videoPercentage prop
@@ -26,8 +26,17 @@
       }
 
       // If we need to update the target time percent
-      if (scrollyVideo && typeof videoPercentage === 'number' && videoPercentage >= 0 && videoPercentage <= 1) {
-        scrollyVideo.setTargetTimePercent(videoPercentage);
+      if (
+        scrollyVideo &&
+        typeof videoPercentage === 'number' &&
+        videoPercentage >= 0 &&
+        videoPercentage <= 1
+      ) {
+        if (restProps.trackScroll) {
+          scrollyVideo.setScrollPercent(videoPercentage);
+        } else {
+          scrollyVideo.setTargetTimePercent(videoPercentage);
+        }
       }
     }
   }

--- a/src/ScrollyVideo.vue
+++ b/src/ScrollyVideo.vue
@@ -41,7 +41,11 @@ export default {
           videoPercentage >= 0 &&
           videoPercentage <= 1
         ) {
-          this.scrollyVideo.setTargetTimePercent(videoPercentage);
+          if (restProps.trackScroll) {
+            this.scrollyVideo.setScrollPercent(videoPercentage);
+          } else {
+            this.scrollyVideo.setTargetTimePercent(videoPercentage);
+          }
         }
       },
       deep: true,


### PR DESCRIPTION
This PR addresses this issue https://github.com/dkaoster/scrolly-video/issues/89.

By design, I add a new callback that replaces `setTargetTimePercent` because it manipulates with `currentTime` which doesn't have a sync with a scroll position (described in issue #89).

So, here we
- keep `scroll` listener of handler `updateScrollPercentage` that uses `setTargetTimePercent` under the hood
- keep `setTargetTimePercent` for non-trackScroll implementation (even though now it's possible to enable both at the same time)
- introduce `setPercentage` in conjunction with `trackScroll`, so here we unlock the possibility to use track scroll and programmatic scroll in the same flow.
