### PR TITLE
feat: add data-scrolly-container attribute to vue and svelte as well

### DIFF
--- a/src/ScrollyVideo.svelte
+++ b/src/ScrollyVideo.svelte
@@ -52,4 +52,4 @@
   });
 </script>
 
-<div bind:this={scrollyVideoContainer} />
+<div bind:this={scrollyVideoContainer} data-scrolly-container />

--- a/src/ScrollyVideo.vue
+++ b/src/ScrollyVideo.vue
@@ -64,5 +64,5 @@ export default {
 </script>
 
 <template>
-  <div ref="containerElement" />
+  <div ref="containerElement" data-scrolly-container />
 </template>


### PR DESCRIPTION
I added it to react JSX in the previous PRs, but I think it can also be useful for Vue and Svelte wrappers, since this is the way how outer code can reach the wrapper node.

Though, it's a static approach. It can also be done via `classNames` but ... let's just keep data attributes until users come with a request for `classNames`.