### PR TITLE
feat: ready callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Add html code to your html component:
 | trackScroll           | Whether this object should automatically respond to scroll                                               | Boolean          | true    |
 | useWebCodecs          | Whether the library should use the webcodecs method, see below                                           | Boolean          | true    |
 | videoPercentage       | Manually specify the position of the video between 0..1, only used for react, vue, and svelte components | Number           |         |
+| onReady               | The callback when it's ready to scroll                                                                   | VoidFunction     |         |
 | debug                 | Whether to log debug information                                                                         | Boolean          | false   |
 
 Additionally, to set currentTime manually:

--- a/src/ScrollyVideo.jsx
+++ b/src/ScrollyVideo.jsx
@@ -19,6 +19,7 @@ const ScrollyVideoComponent = forwardRef(function ScrollyVideoComponent(
     useWebCodecs,
     videoPercentage,
     debug,
+    onReady,
   },
   ref,
 ) {
@@ -28,6 +29,9 @@ const ScrollyVideoComponent = forwardRef(function ScrollyVideoComponent(
 
   const videoPercentageRef = useRef(videoPercentage);
   videoPercentageRef.current = videoPercentage;
+
+  const onReadyRef = useRef(onReady);
+  onReadyRef.current = onReady;
 
   // effect for destroy and recreate on props change (except video percentage)
   useEffect(() => {
@@ -50,6 +54,7 @@ const ScrollyVideoComponent = forwardRef(function ScrollyVideoComponent(
       useWebCodecs,
       debug,
       videoPercentage: videoPercentageRef.current,
+      onReady: onReadyRef.current,
     });
 
     setInstance(scrollyVideo);


### PR DESCRIPTION
It might solve https://github.com/dkaoster/scrolly-video/issues/46

Rewrote` decodeVideo` a little bit for better readability (more linear reading with early return and async-await)

Btw, you do catch first because sometimes it can just produce the empty array by default without `catch`, right?
As I understand, you put `catch` first to "normalize" an empty array and catch both cases later in the last `then`.
Because I wanted to move catch to the bottom but then I understood that it might be a normalization.