### PR TITLE
Improve: programmatic scrolling experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,31 +83,23 @@ Add html code to your html component:
 | sticky                | Whether the video should have `position: sticky`                                                         | Boolean          | true    |
 | full                  | Whether the video should take up the entire viewport                                                     | Boolean          | true    |
 | trackScroll           | Whether this object should automatically respond to scroll                                               | Boolean          | true    |
+| lockScroll            | Whether it ignores human scroll while it runs `setVideoPercentage` with enabled `trackScroll`            | Boolean          | true    |
 | useWebCodecs          | Whether the library should use the webcodecs method, see below                                           | Boolean          | true    |
 | videoPercentage       | Manually specify the position of the video between 0..1, only used for react, vue, and svelte components | Number           |         |
 | onReady               | The callback when it's ready to scroll                                                                   | VoidFunction     |         |
+| onChange              | The callback for video percentage change                                                                 | VoidFunction     |         |
 | debug                 | Whether to log debug information                                                                         | Boolean          | false   |
 
 
 ## Additional callbacks
 
-***setTargetTimePercent***
+***setVideoPercentage***
 
-Description: A way to set currentTime manually. Pass a progress in between of 0 and 1 that specifies the percentage position of the video.
+Description: A way to set currentTime manually. Pass a progress in between of 0 and 1 that specifies the percentage position of the video. If `trackScroll` enabled - it performs scroll automatically.
 
 Signature: `(percentage: number, options: { transitionSpeed: number, (progress: number) => number }) => void`
 
-Example: `scrollyVideo.setTargetTimePercent(0.5, { transitionSpeed: 12, easing: d3.easeLinear })`
-
-<br/>
-
-***setScrollPercent***
-
-Description: A way to set video currentTime manually based on `trackScroll` i.e. pass a progress in between of 0 and 1 that specifies the percentage position of the video and it will scroll smoothly. Make sure to have `trackScroll` enabled.
-
-Signature: `(percentage: number) => void`
-
-Example: `scrollyVideo.setScrollPercent(0.5)`
+Example: `scrollyVideo.setVideoPercentage(0.5, { transitionSpeed: 12, easing: d3.easeLinear })`
 
 
 ## Technical Details and Cross Browser Differences

--- a/src/ScrollyVideo.jsx
+++ b/src/ScrollyVideo.jsx
@@ -16,6 +16,7 @@ const ScrollyVideoComponent = forwardRef(function ScrollyVideoComponent(
     sticky,
     full,
     trackScroll,
+    lockScroll,
     useWebCodecs,
     videoPercentage,
     debug,
@@ -51,6 +52,7 @@ const ScrollyVideoComponent = forwardRef(function ScrollyVideoComponent(
       sticky,
       full,
       trackScroll,
+      lockScroll,
       useWebCodecs,
       debug,
       videoPercentage: videoPercentageRef.current,
@@ -67,6 +69,7 @@ const ScrollyVideoComponent = forwardRef(function ScrollyVideoComponent(
     sticky,
     full,
     trackScroll,
+    lockScroll,
     useWebCodecs,
     debug,
   ]);
@@ -80,13 +83,9 @@ const ScrollyVideoComponent = forwardRef(function ScrollyVideoComponent(
       videoPercentage >= 0 &&
       videoPercentage <= 1
     ) {
-      if (trackScroll) {
-        scrollyVideoRef.current.setScrollPercent(videoPercentage)
-      } else {
-        scrollyVideoRef.current.setTargetTimePercent(videoPercentage);
-      }
+      scrollyVideoRef.current.setVideoPercentage(videoPercentage);
     }
-  }, [videoPercentage, trackScroll]);
+  }, [videoPercentage]);
 
   // effect for unmount
   useEffect(
@@ -101,11 +100,8 @@ const ScrollyVideoComponent = forwardRef(function ScrollyVideoComponent(
   useImperativeHandle(
     ref,
     () => ({
-      setTargetTimePercent: scrollyVideoRef.current
-        ? scrollyVideoRef.current.setTargetTimePercent.bind(instance)
-        : () => {},
-      setScrollPercent: scrollyVideoRef.current
-        ? scrollyVideoRef.current.setScrollPercent.bind(instance)
+      setVideoPercentage: scrollyVideoRef.current
+        ? scrollyVideoRef.current.setVideoPercentage.bind(instance)
         : () => {},
     }),
     [instance],

--- a/src/ScrollyVideo.svelte
+++ b/src/ScrollyVideo.svelte
@@ -32,23 +32,14 @@
         videoPercentage >= 0 &&
         videoPercentage <= 1
       ) {
-        if (restProps.trackScroll) {
-          scrollyVideo.setScrollPercent(videoPercentage);
-        } else {
-          scrollyVideo.setTargetTimePercent(videoPercentage);
-        }
+        scrollyVideo.setVideoPercentage(videoPercentage);
       }
     }
   }
 
-  // export setTargetTimePercent for use in implementations
-  export function setTargetTimePercent(...args) {
-    scrollyVideo.setTargetTimePercent(...args);
-  }
-
-  // export setScrollPercent for use in implementations
-  export function setScrollPercent(...args) {
-    scrollyVideo.setScrollPercent(...args);
+  // export setVideoPercentage for use in implementations
+  export function setVideoPercentage(...args) {
+    scrollyVideo.setVideoPercentage(...args);
   }
 
   // Cleanup the component on destroy

--- a/src/ScrollyVideo.vue
+++ b/src/ScrollyVideo.vue
@@ -20,11 +20,8 @@ export default {
         ...props,
       });
     },
-    setTargetTimePercent(...args) {
-      if (this.scrollyVideo) this.scrollyVideo.setTargetTimePercent(...args);
-    },
-    setScrollPercent(...args) {
-      if (this.scrollyVideo) this.scrollyVideo.setScrollPercent(...args);
+    setVideoPercentage(...args) {
+      if (this.scrollyVideo) this.scrollyVideo.setVideoPercentage(...args);
     },
   },
   watch: {
@@ -47,11 +44,7 @@ export default {
           videoPercentage >= 0 &&
           videoPercentage <= 1
         ) {
-          if (restProps.trackScroll) {
-            this.scrollyVideo.setScrollPercent(videoPercentage);
-          } else {
-            this.scrollyVideo.setTargetTimePercent(videoPercentage);
-          }
+          this.scrollyVideo.setVideoPercentage(videoPercentage);
         }
       },
       deep: true,

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,26 @@
+export function debounce(func, delay = 0) {
+  let timeoutId;
+
+  return function (...args) {
+    const context = this;
+
+    // Clear the previous timeout if it exists
+    clearTimeout(timeoutId);
+
+    // Set a new timeout to call the function later
+    timeoutId = setTimeout(() => {
+      func.apply(context, args);
+    }, delay);
+  };
+}
+
+export const isScrollPositionAtTarget = (
+  targetScrollPosition,
+  threshold = 1,
+) => {
+  // eslint-disable-next-line no-undef
+  const currentScrollPosition = window.pageYOffset;
+  const difference = Math.abs(currentScrollPosition - targetScrollPosition);
+
+  return difference < threshold;
+};


### PR DESCRIPTION
This PR can be treated as a breaking change and touches on several things. Let me describe it by points.

First of all, this PR addresses the [issue](https://github.com/dkaoster/scrolly-video/issues/106) of subsequent `setScrollPercent`.
When we added `setScrollPercent,` it was naively working just by running a browser scroll, so the rest of the code doesn't need a big refactoring because we relied on the `scroll` event.

There are a couple of issues with this:
- a collision of `setScrollPercent`, so `scroll` can't distinguish which scroll we process now. And there is no way to stop the previous scroll from progressing. 
- not supported easing. We play a video with the `trackScroll` setup (like linear scrolling). We can't add easing for `trackScroll` on `event` because some easings progress towards the goal non-linearly, which means you scroll to the bottom, but easing plays in the opposite direction. In addition to the connected video duration to the scroll percentage.

Also, nice to have things are:
- internal state of `videoPercentage`, so we could operate this value in some scenarios, 
- support [onChange](https://github.com/dkaoster/scrolly-video/issues/100) 

Feel free to share your thoughts.
And maybe we finally need to build a repro for advanced cases for easier testing and regression.
One more thing: I added a few lines of code to support `onChange`, but we can do it separately, of course. I just showed how easy it is now.
